### PR TITLE
Added "output" option to specify response format and "verify" option to

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "4.2.*",
-        "guzzlehttp/guzzle": "5.0.*"
+        "illuminate/support": "~4.0|~5.0",
+        "guzzlehttp/guzzle": "5.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Beanstalkhq\\Laramandrill\\": "src/"
+        "psr-4": { 
+            "Beanstalkhq\\Laramandrill\\": "src/Beanstalkhq/Laramandrill/" 
         }
     },
     "minimum-stability": "stable"

--- a/src/Beanstalkhq/Laramandrill/Laramandrill.php
+++ b/src/Beanstalkhq/Laramandrill/Laramandrill.php
@@ -28,7 +28,7 @@ class Laramandrill
 
 		// determine endpoint
 		$client = new Client(['base_url' => 'https://mandrillapp.com/api/1.0/']);
-		$client->setDefaultOption('verify', true);
+		$client->setDefaultOption('verify', $verify);
 		$endpoint = $callName.'.'.$output;
 
 		// build payload

--- a/src/Beanstalkhq/Laramandrill/Laramandrill.php
+++ b/src/Beanstalkhq/Laramandrill/Laramandrill.php
@@ -23,10 +23,13 @@ class Laramandrill
 		}
 		// Setup
 		$api_key = \Config::get('laramandrill::laramandrill.api_key');
+		$verify = \Config::get('laramandrill::laramandrill.verify');
+		$output = \Config::get('laramandrill::laramandrill.output');
 
 		// determine endpoint
 		$client = new Client(['base_url' => 'https://mandrillapp.com/api/1.0/']);
-		$endpoint = $callName.'.json';
+		$client->setDefaultOption('verify', true);
+		$endpoint = $callName.'.'.$output;
 
 		// build payload
 		$arguments['key'] = $api_key;
@@ -42,7 +45,7 @@ class Laramandrill
 			}
 		}
 		return $response->getBody();
-  	}
+	}
 
 	/**
 	 * _validateRequestVerb

--- a/src/config/laramandrill.php
+++ b/src/config/laramandrill.php
@@ -1,9 +1,26 @@
 <?php
  
-return [ 
+return [
 
+	/**
+	 * Set your your api key
+	 * you can find or generate one at https://mandrillapp.com/settings/api
+	 */
+	'api_key' => 'your api key here',
 
-	'api_key' => 'xxxxxxxxxxxxxxxxxx',
+	/**
+	 * Set to false to disable verifying SSL certificate or pass full path string where certificate file is located
+	 * example for Windows: 'C:\Program Files (x86)\Git\bin\curl-ca-bundle.crt'
+	 */
+	'verify' => true,
+
+	/**
+	 * json (default)
+	 * xml
+	 * yaml
+	 * php
+	 */
+	'output' => 'json',
 
 
 ];


### PR DESCRIPTION
Added "output" option to specify response format and "verify" option to set disable verifying or where SSL certificate is located. This will help Windows users
